### PR TITLE
chart: Add optional lists of snapshotClasses and snapshots

### DIFF
--- a/helm/charts/scheduled-volume-snapshotter/README.md
+++ b/helm/charts/scheduled-volume-snapshotter/README.md
@@ -1,4 +1,5 @@
-# Helm Chart
+# scheduled-volume-snapshotter
+
 Using this Helm chart is the easiest way to install the scheduled volume snapshotter. To install with the base configuration, execute the following command:
 
 ```
@@ -17,4 +18,6 @@ helm upgrade --install scheduled-volume-snapshotter \
 | `failedJobsHistoryLimit`      | The number of failed jobs to retain                                                                    | `1`                                      |
 | `rbac.enabled`                | Flag indicating whether the rbac resources should be installed                                         | `true`                                   |
 | `logLevel`                    | The Python log level for the jobs                                                                      | `INFO`                                   |
-| `podAnnotations`              | Annotations to be added to pods	                                                                     | `{}`                                     |
+| `podAnnotations`              | Annotations to be added to pods                                                                        | `{}`                                     |
+| `snapshotClasses`             | Optional list of VolumeSnapshotClass resources                                                         | `[]`                                     |
+| `snapshots`                   | Optional list of ScheduledVolumeSnapshot resources                                                     | `[]`                                     |

--- a/helm/charts/scheduled-volume-snapshotter/templates/scheduledvolumesnapshot.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/scheduledvolumesnapshot.yaml
@@ -1,0 +1,9 @@
+{{ range .Values.snapshots -}}
+---
+apiVersion: k8s.ryanorth.io/v1beta1
+kind: ScheduledVolumeSnapshot
+metadata:
+  {{- toYaml .metadata | nindent 2 }}
+spec:
+  {{- toYaml .spec | nindent 2 }}
+{{ end -}}

--- a/helm/charts/scheduled-volume-snapshotter/templates/volumesnapshotclass.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/volumesnapshotclass.yaml
@@ -1,0 +1,13 @@
+{{ range .Values.snapshotClasses -}}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  {{- toYaml .metadata | nindent 2 }}
+{{- with .parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+driver: {{ .driver }}
+deletionPolicy: {{ .deletionPolicy | default "Delete" }}
+{{ end -}}

--- a/helm/charts/scheduled-volume-snapshotter/values.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/values.yaml
@@ -26,3 +26,25 @@ resources:
 podAnnotations: {}
   #key: "value"
 
+snapshotClasses: []
+  # List of VolumeSnapshotClass
+  #- metadata:
+  #    name: my-snapshotclass
+  #  parameters:
+  #    storage-locations: us-east2
+  #  driver: pd.csi.storage.gke.io
+  #  deletionPolicy: Delete
+
+snapshots: []
+  # List of ScheduledVolumeSnapshot
+  #- metadata:
+  #    name: my-snapshot
+  #    namespace: my-namespace
+  #  spec:
+  #    snapshotClassName: my-snapshotclass
+  #    persistentVolumeClaimName: my-pvc
+  #    snapshotFrequency: 1d
+  #    snapshotRetention: 365d
+  #    snapshotLabels:
+  #      firstLabel: someLabelValue
+  #      secondLabel: anotherLabelValue


### PR DESCRIPTION
In order to set up everything declaratively there needs to be a way to also configure `VolumeSnapshotClass` and `ScheduledVolumeSnapshot` resources. The preferred way would be to add this to the Helm charts you use, but sometimes this might take too long and you just want to quickly set up snapshots.

This PR adds a pretty generic quick way to set up these optional resources.