### PR TITLE
convert  apiextensions.k8s.io/v1beta1 CRD to v1

### DIFF
--- a/helm/charts/scheduled-volume-snapshotter/crds/scheduled-volume-snapshot-crd.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/crds/scheduled-volume-snapshot-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scheduledvolumesnapshots.k8s.ryanorth.io
@@ -9,6 +9,39 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                snapshotClassName:
+                  description: The name of the VolumeSnapshotClass to be used for generating the snapshot.
+                  type: string
+                persistentVolumeClaimName:
+                  description: The name of the persistent volume claim snapshots should be taken against.
+                  type: string
+                snapshotFrequency:
+                  description: >
+                    How often a snapshot should be created against the persistent volume. Value can be provided
+                    as a string (e.g. 30m, 5h, 4d, 1w, etc.) or an integer (interpretted in hours).
+                  x-kubernetes-int-or-string: true
+                snapshotRetention:
+                  description: >
+                    How long a snapshot should be retained. Value can be provided as a string (e.g. 30m, 5h, 4d, 1w, etc.)
+                    or an integer (interpretted in hours). Negative values indicate indefinite retention.
+                  x-kubernetes-int-or-string: true
+                snapshotLabels:
+                  description: Labels to include on the VolumeSnapshot objects.
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - snapshotClassName
+                - persistentVolumeClaimName
+                - snapshotFrequency
+                - snapshotRetention
   scope: Namespaced
   names:
     plural: scheduledvolumesnapshots
@@ -17,40 +50,3 @@ spec:
     listKind: ScheduledVolumeSnapshotList
     shortNames:
       - svs
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
-          type: object
-          properties:
-            snapshotClassName:
-              description: The name of the VolumeSnapshotClass to be used for generating the snapshot.
-              type: string
-            persistentVolumeClaimName:
-              description: The name of the persistent volume claim snapshots should be taken against.
-              type: string
-            snapshotFrequency:
-              description: >
-                How often a snapshot should be created against the persistent volume. Value can be provided
-                as a string (e.g. 30m, 5h, 4d, 1w, etc.) or an integer (interpretted in hours).
-              oneOf:
-                - type: integer
-                - type: string
-            snapshotRetention:
-              description: >
-                How long a snapshot should be retained. Value can be provided as a string (e.g. 30m, 5h, 4d, 1w, etc.)
-                or an integer (interpretted in hours). Negative values indicate indefinite retention.
-              oneOf:
-                - type: integer
-                - type: string
-            snapshotLabels:
-              description: Labels to include on the VolumeSnapshot objects.
-              type: object
-              additionalProperties:
-                type: string
-          required:
-            - snapshotClassName
-            - persistentVolumeClaimName
-            - snapshotFrequency
-            - snapshotRetention

--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "scheduled-snapshot-operator.name" . }}


### PR DESCRIPTION
apiextensions.k8s.io/v1beta1 does not work on k8s 1.22+

This PR fixes #6 

The CRD update enables me to install this chart on AKS 1.22. 

I don't know yet if the scheduler is functional.