### PR TITLE
feat(helm): add support for imagePullSecrets and SecurityContext

### DIFF
--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -16,6 +16,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        {{- if .Values.podSecurityConext }}
+        securityContext:
+{{ toYaml .Values.podSecurityConext | indent 10 }}
+        {{- end }}
         metadata:
           annotations:
 {{ toYaml .Values.podAnnotations | indent 12 }}
@@ -25,8 +29,16 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- if .Values.image.imagePullSecrets }}
+              imagePullSecrets:
+{{ toYaml .Values.image.imagePullSecrets | indent 16 }}
+              {{- end }}
               resources:
 {{ toYaml .Values.resources | indent 16 }}
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 16 }}
+              {{- end }}
               env:
                 - name: LOG_LEVEL
                   value: "{{ .Values.logLevel }}"

--- a/helm/charts/scheduled-volume-snapshotter/values.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/values.yaml
@@ -1,6 +1,9 @@
 image:
   repository: ryaneorth/scheduled-volume-snapshotter
   #tag: latest
+  # List of secrets used to authorize against the remote repo
+  # - name: docker-auth-secret
+  imagePullSecrets: []
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -25,6 +28,14 @@ resources:
 
 podAnnotations: {}
   #key: "value"
+
+# Pod level security context
+# https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+podSecurityConext: {}
+
+# Container level security context
+# https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+containerSecurityContext: {}
 
 snapshotClasses: []
   # List of VolumeSnapshotClass


### PR DESCRIPTION
## Purpose
Improving the extensibility of the helm chart

Adds:
`.Values.image.imagePullSecrets`
Follows the standard k8s pattern of image pull secrets
```
image:
  repository: ...
  imagePullSecrets:
    - name: docker-remote-secret
```

`.Values.podSecurityContext`
Allows passing in a pod level security context, (more info)[https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod]
```
podSecurityContext:
  runAsUser: 9999
```

`.Values.containerSecurityContext`
Allows passing in a pod level security context, (more info)[https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container]
```
podSecurityContext:
  capabilities:
    drop:
      - ALL
```
