### PR TITLE
fix: pod securitycontext, helm cleanup

### DIFF
--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -18,11 +18,11 @@ spec:
       template:
         metadata:
           annotations:
-            {{- toYaml .Values.podAnnotations | indent 12 }}
+            {{- toYaml .Values.podAnnotations | nindent 12 }}
         spec:
           {{- if .Values.podSecurityConext }}
           securityContext:
-            {{- toYaml .Values.podSecurityConext | indent 12 }}
+            {{- toYaml .Values.podSecurityConext | nindent 12 }}
           {{- end }}
           serviceAccountName: {{ include "scheduled-snapshot-operator.name" . }}
           containers:
@@ -31,13 +31,13 @@ spec:
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if .Values.image.imagePullSecrets }}
               imagePullSecrets:
-                {{- toYaml .Values.image.imagePullSecrets | indent 16 }}
+                {{- toYaml .Values.image.imagePullSecrets | nindent 16 }}
               {{- end }}
               resources:
-                {{- toYaml .Values.resources | indent 16 }}
+                {{- toYaml .Values.resources | nindent 16 }}
               {{- if .Values.containerSecurityContext }}
               securityContext:
-                {{- toYaml .Values.containerSecurityContext | indent 16 }}
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
               {{- end }}
               env:
                 - name: LOG_LEVEL

--- a/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/templates/cronjob.yaml
@@ -16,14 +16,14 @@ spec:
   jobTemplate:
     spec:
       template:
-        {{- if .Values.podSecurityConext }}
-        securityContext:
-{{ toYaml .Values.podSecurityConext | indent 10 }}
-        {{- end }}
         metadata:
           annotations:
-{{ toYaml .Values.podAnnotations | indent 12 }}
+            {{- toYaml .Values.podAnnotations | indent 12 }}
         spec:
+          {{- if .Values.podSecurityConext }}
+          securityContext:
+            {{- toYaml .Values.podSecurityConext | indent 12 }}
+          {{- end }}
           serviceAccountName: {{ include "scheduled-snapshot-operator.name" . }}
           containers:
             - name: {{ .Chart.Name }}
@@ -31,13 +31,13 @@ spec:
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               {{- if .Values.image.imagePullSecrets }}
               imagePullSecrets:
-{{ toYaml .Values.image.imagePullSecrets | indent 16 }}
+                {{- toYaml .Values.image.imagePullSecrets | indent 16 }}
               {{- end }}
               resources:
-{{ toYaml .Values.resources | indent 16 }}
+                {{- toYaml .Values.resources | indent 16 }}
               {{- if .Values.containerSecurityContext }}
               securityContext:
-{{ toYaml .Values.containerSecurityContext | indent 16 }}
+                {{- toYaml .Values.containerSecurityContext | indent 16 }}
               {{- end }}
               env:
                 - name: LOG_LEVEL

--- a/helm/charts/scheduled-volume-snapshotter/values.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/values.yaml
@@ -3,7 +3,8 @@ image:
   #tag: latest
   # List of secrets used to authorize against the remote repo
   # - name: docker-auth-secret
-  imagePullSecrets: []
+  imagePullSecrets:
+    - name: adobe-artifactory-cred
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/helm/charts/scheduled-volume-snapshotter/values.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/values.yaml
@@ -3,8 +3,7 @@ image:
   #tag: latest
   # List of secrets used to authorize against the remote repo
   # - name: docker-auth-secret
-  imagePullSecrets:
-    - name: adobe-artifactory-cred
+  imagePullSecrets: []
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Issue: Pod Security Context is positioned outside the spec for the pod, moved inside the spec