### PR TITLE
Reduce vulnerabilities and reduce size of container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3
+FROM python:3.9.13-slim-bullseye
 
 WORKDIR /
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 humanfriendly==7.1
-kubernetes==10.0.1
+kubernetes==10.1.0
+


### PR DESCRIPTION
Image size reduction: 975 MB -> 171 MB (mostly due to -slim version of base image)

Only one high vulnerability remains, in PyYAML package, perhaps due to old kubernetes package.

Could improve https://github.com/ryaneorth/k8s-scheduled-volume-snapshotter/issues/13