### PR TITLE
feat: Added additional printer columns

### DIFF
--- a/helm/charts/scheduled-volume-snapshotter/crds/scheduled-volume-snapshot-crd.yaml
+++ b/helm/charts/scheduled-volume-snapshotter/crds/scheduled-volume-snapshot-crd.yaml
@@ -41,6 +41,22 @@ spec:
                 - persistentVolumeClaimName
                 - snapshotFrequency
                 - snapshotRetention
+      additionalPrinterColumns:
+        - name: PVC
+          type: string
+          jsonPath: .spec.persistentVolumeClaimName
+        - name: SnapshotClassName
+          type: string
+          jsonPath: .spec.snapshotClassName
+        - name: Frequency
+          type: string
+          jsonPath: .spec.snapshotFrequency
+        - name: Retention
+          type: string
+          jsonPath: .spec.snapshotRetention
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
   scope: Namespaced
   names:
     plural: scheduledvolumesnapshots


### PR DESCRIPTION
Changes:
- added additional printer columns when running `kubectl get scheduledvolumesnapshots` 
- the columns are pvc, retention, frequency and snapshot class name